### PR TITLE
Website announcement message configurable by env var

### DIFF
--- a/web/settings.py
+++ b/web/settings.py
@@ -2,6 +2,8 @@
 
 import os
 
+ANNOUNCEMENT = os.environ.get('ANNOUNCEMENT', None)
+
 class Config(object):
     """Base configuration."""
     ENV = 'default'

--- a/web/templates/drawing.html
+++ b/web/templates/drawing.html
@@ -4,6 +4,9 @@
 	<p><em>Draw something amazing in the grid below and we will print it out with microbial ink 
 	- real living bacteria that produce vivid colors! We'll email a photo of
 	your living work of art back to you.</em></p>
+	{% if announcement %}
+	<p><b>{{announcement}}</b></p>
+	{% endif %}
 	<button type="button" class="close" data-dismiss="alert" aria-label="Close">
 		<span aria-hidden="true">&times;</span>
 	</button>

--- a/web/views.py
+++ b/web/views.py
@@ -2,6 +2,7 @@
 
 from flask import (render_template, Blueprint, current_app, request)
 from .api.user.artpiece import DEFAULT_CANVAS
+from .settings import ANNOUNCEMENT
 
 main = Blueprint('main', __name__)
 
@@ -9,7 +10,7 @@ main = Blueprint('main', __name__)
 @main.route('/', methods=('GET', ))
 @main.route('/index', methods=('GET', ))
 def index():
-    return render_template('main.html', canvas_size=DEFAULT_CANVAS)
+    return render_template('main.html', canvas_size=DEFAULT_CANVAS, announcement=ANNOUNCEMENT)
 
 
 @main.route('/art_confirmation', methods=('GET', ))


### PR DESCRIPTION
This method allows a message to be added to the top of the website by adding an environment variable called ANNOUNCEMENT. In this specific case, I'd like to add a note about COVID-19 limitations, but it could work for any kind of special announcement needed.

It's not very idiomatic to the rest of the code. Rather than leverage the API through Javascript, it passes the the announcement as a variable through the view and uses Jinja to render it into the HTML if it exists. So the front-end and back-end are less separated. We can do better.